### PR TITLE
docs: add semantic-release section

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -47,10 +47,16 @@ The __haskell_github_trust__ account does not have upload permission, rather it 
 on [hackage.haskell.org/upload](https://hackage.haskell.org/upload).
 
 > #### Group Accounts
-> 
+>
 > Occasionally organizations want to have a group / organizational account for a package that is maintained by a group of people. The recommended approach for these cases is to only do package uploads from individual accounts and use the group account only for managing the maintainer list for the package.
 
 In this way you can [upload](https://hackage.haskell.org/upload) any package in this org.
+
+## Organization secrets
+
+Some organization secrets are setup to allow performing actions on the
+organization and publishing to Hackage. Check out the
+[`semantic-release`](semantic-release.md) file to learn more.
 
 ## How to add other people’s packages to the Trust
 

--- a/profile/semantic-release.md
+++ b/profile/semantic-release.md
@@ -1,0 +1,73 @@
+# Setting up `semantic-release` for Haskell Github Trust packages
+
+Once a version of your package has been uploaded to Hackage and the trust
+account has been added to the maintainers, you can use the [semantic-release
+action](https://github.com/cycjimmy/semantic-release-action) to publish new
+versions automatically. The organization already has everything configured, you
+only need to configure a few things.
+
+In this example, we use the `stack-upload` plugin to upload to hackage, but feel
+free to use the `cabal` actions if you don't like `stack`. We also use `main` as
+the default branch, make sure to modify the snippets if you use a different
+default branch name.
+
+## Install the Github App on your repository
+The first step is to add the [Github
+app](https://github.com/organizations/haskell-github-trust/settings/installations/79745966)
+to your repository by adding it to the selected repositories in `Repository access`.
+
+## Configure `semantic-release` in your repository
+In your repository at the root, configure `semantic-release` by adding the
+`.releaserc.mjs` at the root:
+
+```javascript
+/**
+ * @type {import('semantic-release').GlobalConfig}
+ */
+export default {
+    branches: ["main"],
+    tagFormat: "${version}",
+    plugins: [
+        "semantic-release-stack-upload",
+    ]
+}
+```
+
+## Add the `semantic-release` action to your repository
+In your repository, in `.github/workflows/semantic-release.yaml`, include this snippet:
+
+```yaml
+---
+name: Semantic release
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Semantic release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: "${{ secrets.SEMANTIC_RELEASE_APP_ID }}"
+          private-key: "${{ secrets.SEMANTIC_RELEASE_PRIVATE_KEY }}"
+
+      - name: Semantic release
+        id: semantic
+        uses: cycjimmy/semantic-release-action@v4
+        env:
+          GITHUB_TOKEN: "${{ steps.app-token.outputs.token }}"
+          HACKAGE_KEY: "${{ secrets.HACKAGE_TOKEN }}"
+
+        with:
+          ci: ${{ github.ref == github.event.repository.default_branch }}
+          extra_plugins: |
+            semantic-release-stack-upload
+```


### PR DESCRIPTION
I've managed to implement automatic `semantic-release` CI that uploads new
versions to Hackage automatically in my recently transferred
[megaparsec-utils](https://github.com/haskell-github-trust/megaparsec-utils)
package, I think it could be useful for other members to be able to do the same.

This new section documents how to make it work for your repository if you want
to use it as well.

EDIT: turns out I had forgotten to remove the `HACKAGE_TOKEN` secret, and since using the `haskell_github_trust` token, it does not have permissions to upload, even candidates. Is it conceivable to convert `haskell_github_trust` to an uploader on Hackage? Otherwise, people might have to configure their own personal token in the repositories, which is not ideal. Let me know what you think :)